### PR TITLE
CP-3237: migrate github actions to warpbuild runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
     timeout-minutes: 10
     outputs:
       code_changed: ${{ steps.changes.outputs.code_changed }}
@@ -82,7 +82,7 @@ jobs:
   auto-tag:
     needs: lint-and-test
     if: github.event_name == 'push' && needs.lint-and-test.outputs.code_changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
     timeout-minutes: 5
     permissions:
       contents: write
@@ -125,7 +125,7 @@ jobs:
   release:
     needs: auto-tag
     if: needs.auto-tag.outputs.created == 'true'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-2x
     timeout-minutes: 5
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
* Replace `runs-on: ubuntu-latest` with WarpBuild `runs-on: warp-ubuntu-latest-x64-2x` in GitHub Actions workflows.
* Aligns this repo with the rest of the kintsugi-tax org (platform and most service repos already on WarpBuild).

## Jira
[CP-3237](https://trykintsugi.atlassian.net/browse/CP-3237)

## Tests
CI on this PR should confirm jobs run on WarpBuild runners.

## Document Checklist
- [x] N/A — runner label change only

[CP-3237]: https://trykintsugi.atlassian.net/browse/CP-3237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner label-only change with no application or workflow logic changes; main risk is CI failing if WarpBuild labels or org integration are misconfigured.
> 
> **Overview**
> Switches all CI jobs in `.github/workflows/ci.yml` from GitHub-hosted `ubuntu-latest` to WarpBuild **`warp-ubuntu-latest-x64-2x`** runners.
> 
> **`lint-and-test`**, **`auto-tag`**, and **`release`** keep the same steps, timeouts, and conditions; only the `runs-on` label changes so this repo matches the org’s WarpBuild setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0400e3441023780cbbcd287d4d722ba57355d306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->