### PR TITLE
chore: fix Dependabot version-bump gate and stop tightening squawk-cli

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # squawk-cli's >=2.0 floor is intentionally broad so consumers can pin any
+      # squawk 2.x via additional_dependencies. Do not let Dependabot tighten it.
+      - dependency-name: "squawk-cli"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
           fi
           echo "Versions match: $PYPROJECT_VERSION"
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          # Dependabot never bumps the package version, only dependencies, so
+          # exempt it from the version-bump requirement or its dependency PRs
+          # (which edit pyproject.toml) would always fail this check.
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.actor }}" != "dependabot[bot]" ]; then
             git fetch origin main --depth=1
             MAIN_VERSION=$(git show origin/main:pyproject.toml | python -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['tool']['poetry']['version'])" || true)
             if [ -z "$MAIN_VERSION" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,10 @@ jobs:
 
           # Dependabot never bumps the package version, only dependencies, so
           # exempt it from the version-bump requirement or its dependency PRs
-          # (which edit pyproject.toml) would always fail this check.
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.actor }}" != "dependabot[bot]" ]; then
+          # (which edit pyproject.toml) would always fail this check. Key off the
+          # PR author, not github.actor: actor becomes the human on an Update-branch
+          # or manual push, which would wrongly re-enable the check on a bot PR.
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.user.login }}" != "dependabot[bot]" ]; then
             git fetch origin main --depth=1
             MAIN_VERSION=$(git show origin/main:pyproject.toml | python -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['tool']['poetry']['version'])" || true)
             if [ -z "$MAIN_VERSION" ]; then


### PR DESCRIPTION
## Summary
Follow-ups surfaced by the first Dependabot PRs (#12, #13):

- **Exempt Dependabot from the version-bump gate** (`ci.yml`): the "version must differ from main" check fails on any Dependabot pip PR, because Dependabot edits `pyproject.toml` (dependency constraints) but never bumps the package version. Skipped for `dependabot[bot]`; dependency changes roll into the next release.
- **Stop tightening `squawk-cli`** (`dependabot.yml`): `versioning-strategy: increase` was raising the intentional `>=2.0` floor (e.g. to `>=2.61.0`), which would force consumers off their own `additional_dependencies` pins. Now ignored.

Also created the missing `dependencies` label so Dependabot can apply it.

## Notes
- After this merges, Dependabot re-runs and #13 comes back clean (no squawk-cli bump, gate passes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and Dependabot config only; no runtime package or security logic changes.
> 
> **Overview**
> Fixes CI and Dependabot behavior so **dependency-only bot PRs** can pass without manual version bumps or unwanted constraint changes.
> 
> **CI** still requires `pyproject.toml` and `__init__.py` versions to match, but the **“version must differ from main”** step now runs only when the PR author is not `dependabot[bot]` (using `pull_request.user.login`, not `github.actor`, so Update-branch pushes don’t accidentally re-apply the gate).
> 
> **Dependabot** adds an explicit **ignore** for `squawk-cli` so `versioning-strategy: increase` won’t tighten the intentional broad `>=2.0` floor that lets hook consumers pin via `additional_dependencies`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 769aff39a9e14e1b853d509c2760e96bc78f6f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->